### PR TITLE
Add Q/A to FAQ about finding app id

### DIFF
--- a/_includes/faq.html
+++ b/_includes/faq.html
@@ -42,3 +42,17 @@
     </p>
   </div>
 </div>
+
+<div class="row">
+  <div class="col-6">
+    <b>How can I find the corresponding app id?</b>
+    <p>
+      The easiest way to lookup an app id manually is using the
+      <a href="https://steamdb.info">steamdb.info</a> website.
+
+      For getting the app id programmatically it's recommended to utilize the
+      <i>GetAppList</i> endpoint on the Steam API:
+      <a href="https://api.steampowered.com/ISteamApps/GetAppList/v2/">api.steampowered.com/ISteamApps/GetAppList/v2/</a>
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
Seeing the main purpose of the API is to find steam data on specific app id's, the way of finding the corresponding app id's should be mentioned somewhere on the website. This PR will add another question/answer to the FAQ part of the website that shows two methods of finding the corresponding app id.