### PR TITLE
Add counter.dev analytics

### DIFF
--- a/_includes/script.html
+++ b/_includes/script.html
@@ -65,3 +65,9 @@ var apimock = new Vue({
 
 });
 </script>
+<script>
+  if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0) {
+    fetch("https://counter.dev/track?"+new URLSearchParams({referrer:document.referrer,screen:screen.width+"x"+screen.height,user:"steamcmd",utcoffset:"1"}))
+  };
+  sessionStorage.setItem("_swa","1");
+</script>


### PR DESCRIPTION
This PR will add basic privacy friendly web analytics with [counter.dev](https://counter.dev/). This method leaves no cookies and does not allow fingerprinting or other ways of identifying. I added some new lines to make it a bit more readable. The one-liner given by [counter.dev](https://counter.dev/) is:
```
<script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.dev/track?"+new URLSearchParams({referrer:document.referrer,screen:screen.width+"x"+screen.height,user:"steamcmd",utcoffset:"1"}))};sessionStorage.setItem("_swa","1");</script>
```